### PR TITLE
Fix oauth not working in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN mv /usr/local/lib/python3.10/site-packages/lib/python3.10/site-packages/* /u
 COPY zotify /app/zotify
 
 WORKDIR /app
+EXPOSE 4381
 CMD ["python3", "-m", "zotify"]

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ The value is relative to the `ROOT_PATH` directory and may contain the following
 
 ### Create and run a container from the image
 
-`docker run --rm -v "$PWD/Zotify Music:/root/Music/Zotify Music" -v "$PWD/Zotify Podcasts:/root/Music/Zotify Podcasts" -it zotify`
+`docker run --rm -p 4381:4381 -v "$PWD/Zotify Music:/root/Music/Zotify Music" -v "$PWD/Zotify Podcasts:/root/Music/Zotify Podcasts" -it zotify`
 
 ## Common Questions
 

--- a/zotify/__init__.py
+++ b/zotify/__init__.py
@@ -335,7 +335,7 @@ class OAuth:
         self.__token = TokenProvider.StoredToken(response.json())
     
     def __run_server(self) -> None:
-        server_address = ("127.0.0.1", 4381)
+        server_address = ("0.0.0.0", 4381)
         httpd = self.OAuthHTTPServer(server_address, self.RequestHandler, self)
         httpd.authenticator = self
         httpd.serve_forever()


### PR DESCRIPTION
This helped me to authenticate the client within docker from a web browser on the host after opening the link. Should fix https://github.com/Googolplexed0/zotify/issues/17 and https://github.com/Googolplexed0/zotify/issues/20