### PR TITLE
Add lossless support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Set arguments in the commandline like this: `-ie False` or `--codec mp3`. Wrap c
 | Encoding Options             | Command Line Config Flag            | Description                                                                              | Default Value |
 |------------------------------|-------------------------------------|------------------------------------------------------------------------------------------|---------------|
 | `DOWNLOAD_FORMAT`            | `--codec`, `--download-format`      | Audio codec of downloads, copy avoids remuxing (aac, fdk_aac, mp3, ogg, opus, vorbis)    | copy          |
-| `DOWNLOAD_QUALITY`           | `-q`, `--download-quality`          | Audio quality of downloads, auto selects highest available (normal, high, very_high*)    | auto          |
+| `DOWNLOAD_QUALITY`           | `-q`, `--download-quality`          | Audio quality of downloads, auto selects highest available (normal, high, very_high*, lossless*)    | auto          |
 | `TRANSCODE_BITRATE`          | `-b`, `--bitrate`                   | Overwrite the bitrate for FFMPEG encoding (not recommended)                              |               |
 
 | Archive Options              | Command Line Config Flag            | Description                                                                  | Default Value             |
@@ -194,7 +194,7 @@ Set arguments in the commandline like this: `-ie False` or `--codec mp3`. Wrap c
 | `PRINT_API_ERRORS`           | `--print-api-errors`                | Show API errors                                                              | True                      |
 | `FFMPEG_LOG_LEVEL`           | `--ffmpeg-log-level`                | FFMPEG's logged level of detail when completing a transcoded download        | error                     |
 
-\* very_high (320k) is limited to Premium accounts only  
+\* very_high (320k) and lossless is limited to Premium accounts only  
 
 </details>
 

--- a/zotify/app.py
+++ b/zotify/app.py
@@ -230,10 +230,11 @@ def client(args: Namespace) -> None:
     Printer.splash()
     
     quality_options = {
-        'auto': AudioQuality.VERY_HIGH if Zotify.check_premium() else AudioQuality.HIGH,
-        'normal': AudioQuality.NORMAL,
-        'high': AudioQuality.HIGH,
-        'very_high': AudioQuality.VERY_HIGH
+        "auto": AudioQuality.VERY_HIGH if Zotify.check_premium() else AudioQuality.HIGH,
+        "normal": AudioQuality.NORMAL,
+        "high": AudioQuality.HIGH,
+        "very_high": AudioQuality.VERY_HIGH,
+        "lossless": AudioQuality.LOSSLESS,
     }
     Zotify.DOWNLOAD_QUALITY = quality_options.get(Zotify.CONFIG.get_download_quality(),
                                                   quality_options["auto"])


### PR DESCRIPTION
Hooking up the changes from
https://github.com/kokarare1212/librespot-python/pull/316

### Verification

```
$ python -m zotify 'https://open.spotify.com/track/1...'
$ file /path/to/track.ogg: Ogg data, Vorbis audio, stereo, 44100 Hz, ~160000 bps
$ python -m zotify -q lossless 'https://open.spotify.com/track/2...'
$ file /path/to/track2.ogg: Ogg data, Vorbis audio, stereo, 44100 Hz, ~320000 bps
```


Completes #72, barring https://github.com/kokarare1212/librespot-python/issues/320.

This does not transition to the newly introduced classes, though.