### PR TITLE
Fix mkdir in get_credentials_location

### DIFF
--- a/zotify/config.py
+++ b/zotify/config.py
@@ -302,9 +302,7 @@ class Config:
             else:
                 credentials_path = PurePath(cred_path_str)
         
-        credentials = Path(credentials_path).expanduser()
-        if credentials.is_dir():
-            credentials = credentials / 'credentials.json'
+        credentials = Path(credentials_path).expanduser() / 'credentials.json'
         credentials.parent.mkdir(parents=True, exist_ok=True)
         return PurePath(credentials)
     


### PR DESCRIPTION
On the first startup the zotify directory does not exist, for get_credentials_location the is_dir() check is false so the filename is not added and the zotify directory becomes the credentials file, causing an exception inside get_song_archive_location when it tries to create the song_archive directory inside a file.
This PR fix the issue