### PR TITLE
fix metadata backfill for playlist tracks after hasMetadata is set

### DIFF
--- a/zotify/api.py
+++ b/zotify/api.py
@@ -413,8 +413,10 @@ class Content(HierarchicalNode):
             elif relative and k in {ADDED_AT, ADDED_BY, ALBUM_GROUP, IS_LOCAL}:
                 relational_attr: dict[Container, str | bool | User] = getattr(self, k)
                 relational_attr.update({relative: v})
-            elif not self.hasMetadata:
-                setattr(self, k, v)
+            else:
+                current_val = getattr(self, k, None)
+                if not self.hasMetadata or current_val is None:
+                    setattr(self, k, v)
     
     def parse_relatives(self, resps: list[dict[str, str] | None], RelativeClasses: type[Content] | tuple[type[Content]],
                         make_parent: bool = False) -> list[Content | Container | None]:


### PR DESCRIPTION
playlist track objects could get hasMetadata=True as soon as the track name was set, which prevented later metadata filling from filling missing fields.

instead, allow later metadata parses, including fetch_extra_metadata, to populate fields that are still None. this fixes missing album track numbers when downloading tracks from playlists.