### PR TITLE
gets display_name from librespot

### DIFF
--- a/zotify/api.py
+++ b/zotify/api.py
@@ -197,12 +197,11 @@ class Content(HierarchicalNode):
                     if not uri:  uri = f":local:{type_attr_and_ind.lower()}:{name}:::"
                     item[URI] = uri
                 
-                def unknown_user(username: str | None) -> dict | None:
+                def ensure_user_resp(username: str | None) -> dict | None:
                     if not username: return None
-                    display_name = Zotify.get_user_display_name(username)
-                    return { URI : f":{USER}:{username}",
-                             TYPE: USER,
-                             DISPLAY_NAME: display_name   }
+                    return {URI         : f":{USER}:{username}",
+                            TYPE        : USER,
+                            DISPLAY_NAME: User.fetch_display_name(username)}
                 
                 activity_period             : list[dict]        = resp.get(ACTIVITY_PERIOD)
                 if activity_period:
@@ -274,7 +273,7 @@ class Content(HierarchicalNode):
                             if attr is None: continue
                             ensure_uri(item, TRACK + str(i+1))
                             item[ADDED_AT] = timestamp_utc(attr.get(TIMESTAMP))
-                            item[ADDED_BY] = unknown_user(attr.get(ADDED_BY))
+                            item[ADDED_BY] = ensure_user_resp(attr.get(ADDED_BY))
                             item[ITEM_ID] = attr.get(ITEM_ID)
                         self.tracks_or_eps = obj.parse_relatives(items, (Track, Episode))
                         self.needs_recursion = True
@@ -329,7 +328,7 @@ class Content(HierarchicalNode):
                 
                 owner_username              : str               = resp.get(OWNER_USERNAME)
                 if owner_username:
-                    resp[OWNER]                                 = unknown_user(owner_username)
+                    resp[OWNER]                                 = ensure_user_resp(owner_username)
                 
                 owner                       : dict              = resp.get(OWNER)
                 if owner:
@@ -1304,10 +1303,21 @@ class Playlist(Container):
 
 class User(Container):
     _contains = Playlist
+    _display_name_map = {}
+    
     def __init__(self, uri: str):
         super().__init__(uri)
         self.display_name   : str   = None
         self.external_urls  : dict  = None
+    
+    @classmethod
+    def fetch_display_name(cls, username: str) -> str:
+        display_name = cls._display_name_map.get(username)
+        if display_name: return display_name
+        
+        user_profile = Zotify.get_user_profile(username)
+        cls._display_name_map[username] = user_profile.get(NAME, username)
+        return cls._display_name_map[username]
 
 
 class Album(Container):

--- a/zotify/api.py
+++ b/zotify/api.py
@@ -197,11 +197,12 @@ class Content(HierarchicalNode):
                     if not uri:  uri = f":local:{type_attr_and_ind.lower()}:{name}:::"
                     item[URI] = uri
                 
-                def unknown_user(owner_username: str | None) -> dict | None:
-                    if not owner_username: return None
-                    return { URI : f":{USER}:{owner_username}",
+                def unknown_user(username: str | None) -> dict | None:
+                    if not username: return None
+                    display_name = Zotify.get_user_display_name(username)
+                    return { URI : f":{USER}:{username}",
                              TYPE: USER,
-                             DISPLAY_NAME: owner_username   }
+                             DISPLAY_NAME: display_name   }
                 
                 activity_period             : list[dict]        = resp.get(ACTIVITY_PERIOD)
                 if activity_period:
@@ -1305,7 +1306,7 @@ class User(Container):
     _contains = Playlist
     def __init__(self, uri: str):
         super().__init__(uri)
-        self.display_name   : str   = None # will be id if not permit_client_api()
+        self.display_name   : str   = None
         self.external_urls  : dict  = None
 
 

--- a/zotify/config.py
+++ b/zotify/config.py
@@ -644,11 +644,12 @@ class Zotify:
     DOWNLOAD_BITRATE        : str                       = None
     
     # DYNAMICS
-    TOTAL_API_CALLS         : int   = None
-    DATETIME_LAUNCH         : str   = None
-    LEGACY_API_ENDOINTS     : bool  = True
-    FORCE_LIBRE_METADATA    : bool  = False
-    FORCE_STREAM_API_CALLS  : bool  = False
+    TOTAL_API_CALLS         : int             = None
+    DATETIME_LAUNCH         : str             = None
+    LEGACY_API_ENDOINTS     : bool            = True
+    FORCE_LIBRE_METADATA    : bool            = False
+    FORCE_STREAM_API_CALLS  : bool            = False
+    USER_DISPLAY_NAME_MAP   : dict[str, str]  = None
     
     @classmethod
     def start(cls) -> None:
@@ -656,6 +657,7 @@ class Zotify:
             Printer.debug(f"Total API Calls: {cls.TOTAL_API_CALLS}")
         cls.DATETIME_LAUNCH = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         cls.TOTAL_API_CALLS = 0
+        cls.USER_DISPLAY_NAME_MAP = {}
     
     @classmethod
     def login(cls, args):
@@ -784,6 +786,20 @@ class Zotify:
     @staticmethod
     def hex_id_from_file_id(file_id: str) -> str:
         return hexlify(b64decode(file_id.encode())).decode()
+
+    @staticmethod
+    def get_user_display_name(username: str) -> str:
+        try:
+            display_name = Zotify.USER_DISPLAY_NAME_MAP.get(username)
+            if not display_name:
+                user_profile = Zotify.SESSION.api().get_user_profile(username, 0, 0)
+                display_name = user_profile[NAME]
+                Zotify.USER_DISPLAY_NAME_MAP[username] = display_name
+            return display_name
+        except Exception as e:
+            Printer.debug(f"Failed to fetch display name for {username}")
+            Printer.traceback(e)
+            return {}
     
     @staticmethod
     def to_libre_content(ContClass: type, uri: str) -> metadata.Id | None:

--- a/zotify/config.py
+++ b/zotify/config.py
@@ -632,8 +632,12 @@ class Config:
 
 
 class Zotify:
-    # STATICS
+    # STATIC
     VERSION                                             = version("zotify")
+    LEGACY_API_ENDOINTS     : bool                      = True
+    FORCE_LIBRE_METADATA    : bool                      = True
+    
+    # STATIC AFTER BOOT
     CONFIG                  : Config                    = Config()
     CRED_FILE               : PurePath                  = None
     OAUTH                   : OAuth                     = None
@@ -643,13 +647,12 @@ class Zotify:
     DOWNLOAD_QUALITY        : FormatOnlyAudioQuality    = None
     DOWNLOAD_BITRATE        : str                       = None
     
-    # DYNAMICS
-    TOTAL_API_CALLS         : int             = None
-    DATETIME_LAUNCH         : str             = None
-    LEGACY_API_ENDOINTS     : bool            = True
-    FORCE_LIBRE_METADATA    : bool            = False
-    FORCE_STREAM_API_CALLS  : bool            = False
-    USER_DISPLAY_NAME_MAP   : dict[str, str]  = None
+    # DYNAMIC PER SESSION
+    FORCE_STREAM_API_CALLS  : bool                      = False
+    
+    # DYNAMIC PER QUERY
+    TOTAL_API_CALLS         : int                       = None
+    DATETIME_LAUNCH         : str                       = None
     
     @classmethod
     def start(cls) -> None:
@@ -657,7 +660,6 @@ class Zotify:
             Printer.debug(f"Total API Calls: {cls.TOTAL_API_CALLS}")
         cls.DATETIME_LAUNCH = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         cls.TOTAL_API_CALLS = 0
-        cls.USER_DISPLAY_NAME_MAP = {}
     
     @classmethod
     def login(cls, args):
@@ -786,20 +788,6 @@ class Zotify:
     @staticmethod
     def hex_id_from_file_id(file_id: str) -> str:
         return hexlify(b64decode(file_id.encode())).decode()
-
-    @staticmethod
-    def get_user_display_name(username: str) -> str:
-        try:
-            display_name = Zotify.USER_DISPLAY_NAME_MAP.get(username)
-            if not display_name:
-                user_profile = Zotify.SESSION.api().get_user_profile(username, 0, 0)
-                display_name = user_profile[NAME]
-                Zotify.USER_DISPLAY_NAME_MAP[username] = display_name
-            return display_name
-        except Exception as e:
-            Printer.debug(f"Failed to fetch display name for {username}")
-            Printer.traceback(e)
-            return {}
     
     @staticmethod
     def to_libre_content(ContClass: type, uri: str) -> metadata.Id | None:
@@ -976,6 +964,15 @@ class Zotify:
                                                   'AN UNEXPECTED ERROR OCCURED - CHECK LOGS FOR DETAILS')
             Printer.traceback(e)
         return None
+    
+    @classmethod
+    def get_user_profile(cls, username: str) -> dict:
+        try:
+            return cls.SESSION.api().get_user_profile(username)
+        except Exception as e:
+            Printer.debug(f"Failed to fetch user profile for {username}")
+            Printer.traceback(e)
+            return {}
     
     @classmethod
     def end(cls) -> None:


### PR DESCRIPTION
This depends on https://github.com/Googolplexed0/librespot-python/pull/2 getting pulled, as I used the new function added to make this work.

When the "unknown_user" function is called to set the display_name, instead of assigning it the id, i send the id to the new librespot function `get_user_profile` to return the user display name. If the display name is already in the dictionary `USER_DISPLAY_NAME_MAP` then it will use that instead of making another call. This should fix #206