### PR TITLE
fix: alias platform.system to stop shadowing os.system in termoutput

### DIFF
--- a/zotify/termoutput.py
+++ b/zotify/termoutput.py
@@ -5,7 +5,7 @@ from functools import partial
 from itertools import cycle
 from mutagen import FileType
 from os import get_terminal_size, system
-from platform import system
+from platform import system as platform_system
 from pprint import pformat
 from re import split, escape
 from tabulate import tabulate
@@ -239,7 +239,7 @@ class Printer:
     @staticmethod
     def clear() -> None:
         """ Clear the console window """
-        if system() == WINDOWS_SYSTEM:
+        if platform_system() == WINDOWS_SYSTEM:
             system('cls')
         else:
             system('clear')


### PR DESCRIPTION
Fixes #219. `from os import system` is immediately shadowed by `from platform import system` in `zotify/termoutput.py`, so `Printer.clear()` calls `platform.system('clear')` and raises `TypeError`. Aliased `platform.system` as `platform_system` so the os-level shell call works on all platforms.
