### PR TITLE
guard against duration_ms=None at fetch_content_stream rate-limiter

### DIFF
--- a/zotify/api.py
+++ b/zotify/api.py
@@ -589,7 +589,7 @@ class DLContent(Content):
             with open(temppath, 'wb') as file:
                 no_responses = 0
                 time_start = time.time()
-                t_per_byte = self.duration_ms / 1000. / stream.size * Zotify.CONFIG.get_dl_rate_limter()
+                t_per_byte = (self.duration_ms / 1000. / stream.size * Zotify.CONFIG.get_dl_rate_limter()) if self.duration_ms else 0
                 while no_responses < 5:
                     bytes_r = file.write(stream.stream().read(Zotify.CONFIG.get_chunk_size()))
                     if bytes_r:


### PR DESCRIPTION
👋 First off — thank you for this project! I'm a Spotify Premium user running this on a Radxa Zero 3E homelab box, and the architecture (the `efficient-api` work, the type-of-content abstraction, the clean separation between `api.py` and `librespot` glue) is a joy to read through. 🎶

That said, hit a small `None`-handling bug while downloading a podcast episode and figured I'd send the one-line fix upstream rather than only keep it on my side.

## Bug

Podcast episodes with `null` duration metadata crash at `zotify/api.py:592`:

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

The rate-limiter math evaluates `self.duration_ms / 1000.` left-to-right before `* DOWNLOAD_RATE_LIMITER` (default `0.0`) can short-circuit. So it crashes even when the user hasn't opted into throttling.

## Repro (v0.17.3)

```
zotify https://open.spotify.com/episode/72U2fjs0O8WEbLPvVjr2sK
```

Episode is audio-only (`hasVideo: false`), playable, and Spotify's embed reports a valid duration (1087373 ms) — so the metadata gap is on zotify's fetch path.

## Fix

Short-circuit when duration is unknown:

```python
t_per_byte = (self.duration_ms / 1000. / stream.size * Zotify.CONFIG.get_dl_rate_limter()) if self.duration_ms else 0
```

- Default limiter `0.0` → no behavior change for non-throttling users.
- Throttling users skip per-byte sleep for the affected episode (math can't be computed without duration).

## Verified

Applied patch in venv, retried failing URL on v0.17.3 → downloaded successfully in 2m42s, MP3 + ID3 written. ✅

## Re #91

#91 was closed by `75260bb` (v0.10.14, fix for missing `partner_url`). That fix is on main; this is a separate `Episode is None` variant on the rate-limiter path that survived. Happy to reopen #91 as follow-up or treat as a sibling — your call. 🙏